### PR TITLE
update the connector to the latest API version

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticatorConstants.java
@@ -28,11 +28,11 @@ public class PinterestAuthenticatorConstants {
 	}
 
 	//Pinterest authorize endpoint URL.
-	public static final String PINTEREST_OAUTH_ENDPOINT = "https://api.pinterest.com/oauth/";
+	public static final String PINTEREST_OAUTH_ENDPOINT = "https://www.pinterest.com/oauth/";
 	//Pinterest token  endpoint URL.
-	public static final String PINTEREST_TOKEN_ENDPOINT = "https://api.pinterest.com/v1/oauth/token";
+	public static final String PINTEREST_TOKEN_ENDPOINT = "https://api.pinterest.com/v5/oauth/token";
 	//Pinterest user info endpoint URL.
-	public static final String PINTEREST_USERINFO_ENDPOINT = "https://api.pinterest.com/v1/me";
+	public static final String PINTEREST_USERINFO_ENDPOINT = "https://api.pinterest.com/v5/user_account";
 	//Pinterest connector friendly name.
 	public static final String PINTEREST_CONNECTOR_FRIENDLY_NAME = "Pinterest Authenticator";
 	//Pinterest connector name.
@@ -49,12 +49,12 @@ public class PinterestAuthenticatorConstants {
 	public static final String CLIENT_SECRET = "Client Secret";
 	//The reply URL of the application.
 	public static final String CALLBACK_URL = "callbackUrl";
-	//The ID of the user.
-	public static final String USER_ID = "id";
+	//username of the user.
+	public static final String USERNAME = "username";
 	//The claim dialect uri.
 	public static final String CLAIM_DIALECT_URI = "http://wso2.org/pinterest/claims";
 	//A comma-separated list of permission scopes
-	public static final String PINTEREST_BASIC_SCOPE = "read_public,write_public";
+	public static final String PINTEREST_BASIC_SCOPE = "user_accounts:read";
 	//The Http get method
 	public static final String HTTP_GET_METHOD = "GET";
 	//Root element of the json response

--- a/component/src/test/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestTest.java
+++ b/component/src/test/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestTest.java
@@ -182,7 +182,7 @@ public class PinterestTest extends PowerMockTestCase {
                 thenReturn(authAuthzResponse);
         PowerMockito.mockStatic(OAuthClientRequest.class);
         Mockito.when(OAuthClientRequest.tokenLocation(Mockito.anyString())).thenReturn(new OAuthClientRequest.
-                TokenRequestBuilder("https://api.pinterest.com/v1/oauth/token"));
+                TokenRequestBuilder("https://api.pinterest.com/v5/oauth/token"));
         PowerMockito.whenNew(OAuthClient.class).withAnyArguments().thenReturn(oAuthClient);
         Mockito.when(mockOAuthClient.accessToken(mockOAuthClientRequest)).thenReturn(oAuthJSONAccessTokenResponse);
         Mockito.when(oAuthClient.accessToken(Mockito.any(OAuthClientRequest.class))).


### PR DESCRIPTION
## Purpose
The Connector version 1.0.0 was implemented with Pinterest API version 1 and it returns `API method not found` error during the token generation. Hence, Updating the connector implementation to latest API version [1]

Demo
[Screencast from 12-10-22 22:10:50.webm](https://user-images.githubusercontent.com/28682701/195404005-9f055f91-834e-4120-bb7b-c31d317054d5.webm)

[1] https://developers.pinterest.com/docs/api/v5

## Related issue
- https://github.com/wso2/product-is/issues/15032