### PR TITLE
Add SCR dependency

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -183,6 +183,11 @@
             <version>${powermock.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <version>${felix.scr.version}</version>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>${log4j.version}</version>

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
@@ -220,7 +220,7 @@ public class PinterestAuthenticator extends OpenIDConnectAuthenticator implement
 	 * @param request  the http request
 	 * @param response the http response
 	 * @param context  the authentication context
-	 * @throws AuthenticationFailedException if the operation failed
+	 * @throws AuthenticationFailedException If the operation failed.
 	 */
 	@Override
 	protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
@@ -174,7 +174,7 @@ public class PinterestAuthenticator extends OpenIDConnectAuthenticator implement
 	 * @param request  the http request
 	 * @param response the http response
 	 * @param context  the authentication context
-	 * @throws AuthenticationFailedException if the operation failed.
+	 * @throws AuthenticationFailedException If the operation failed.
 	 */
 	@Override
 	protected void initiateAuthenticationRequest(HttpServletRequest request, HttpServletResponse response,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
@@ -174,7 +174,7 @@ public class PinterestAuthenticator extends OpenIDConnectAuthenticator implement
 	 * @param request  the http request
 	 * @param response the http response
 	 * @param context  the authentication context
-	 * @throws AuthenticationFailedException
+	 * @throws AuthenticationFailedException if the operation failed
 	 */
 	@Override
 	protected void initiateAuthenticationRequest(HttpServletRequest request, HttpServletResponse response,
@@ -220,7 +220,7 @@ public class PinterestAuthenticator extends OpenIDConnectAuthenticator implement
 	 * @param request  the http request
 	 * @param response the http response
 	 * @param context  the authentication context
-	 * @throws AuthenticationFailedException
+	 * @throws AuthenticationFailedException if the operation failed
 	 */
 	@Override
 	protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java
@@ -174,7 +174,7 @@ public class PinterestAuthenticator extends OpenIDConnectAuthenticator implement
 	 * @param request  the http request
 	 * @param response the http response
 	 * @param context  the authentication context
-	 * @throws AuthenticationFailedException if the operation failed
+	 * @throws AuthenticationFailedException if the operation failed.
 	 */
 	@Override
 	protected void initiateAuthenticationRequest(HttpServletRequest request, HttpServletResponse response,

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,11 @@
             <version>${powermock.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <version>${felix.scr.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
@@ -312,6 +317,7 @@
         <carbon.identity.version>5.0.7</carbon.identity.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.4.3</carbon.kernel.version>
+        <felix.scr.version>1.12.0</felix.scr.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
## Purpose
Adding SCR dependency and providing description to solve the following build errors

```
[INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.1:jar (attach-javadocs) on project org.wso2.carbon.extension.identity.authenticator.pinterest.connector: MavenReportException: Error while generating Javadoc: 
[INFO] [ERROR] Exit code: 1 - /home/jenkins/workspace/identity-extensions/identity-outbound-auth-pinterest/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/internal/PinterestAuthenticatorServiceComponent.java:31: error: unknown tag: scr.component
[INFO] [ERROR]  * @scr.component name="identity.application.authenticator.pinterest.component" immediate="true"
[INFO] [ERROR]    ^
[INFO] [ERROR] /home/jenkins/workspace/identity-extensions/identity-outbound-auth-pinterest/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java:177: warning: no description for @throws
[INFO] [ERROR] 	 * @throws AuthenticationFailedException
[INFO] [ERROR] 	   ^
[INFO] [ERROR] /home/jenkins/workspace/identity-extensions/identity-outbound-auth-pinterest/component/src/main/java/org/wso2/carbon/identity/authenticator/pinterest/PinterestAuthenticator.java:223: warning: no description for @throws
[INFO] [ERROR] 	 * @throws AuthenticationFailedException
```